### PR TITLE
Remove {: .btn}

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # dcppc-workshops
 Organizing the monthly DCPPC workshops.
 
-Click on the [Projects](https://github.com/dcppc/dcppc-workshops/projects){: .btn} 
+Click on the [Projects](https://github.com/dcppc/dcppc-workshops/projects) 
 button above to view the dashboards for each montly meeting. 
-Or, click the [Issues](https://github.com/dcppc/dcppc-workshops/issues){: .btn} 
+Or, click the [Issues](https://github.com/dcppc/dcppc-workshops/issues) 
 to view all the issues related to the workshops in list form. 
 
 All members of the Commons are expected to agree with the our 


### PR DESCRIPTION

![screen shot 2018-05-07 at 09 34 10](https://user-images.githubusercontent.com/298927/39713015-ff821274-51d9-11e8-87de-0941f8f33f74.png)

This isn't valid Github-flavoured markdown and isn't rendering, instead is appearing as code in the README