### PR TITLE
add links to workshop outputs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ The issues and projects and documents within this repository are used to organiz
 * Resources: [workshop website](http://nih-data-commons.us/2018-september-workshop/), [GitHub repository](https://github.com/dcppc/2018-september-workshop)
 
 ### August Workshop: August 27-28, 2018 in Chicago, IL
-* Resources: [workshop website](http://nih-data-commons.us/2018-august-workshop/), [GitHub repository](https://github.com/dcppc/2018-august-workshop)  
+* Resources: [workshop website](http://nih-data-commons.us/2018-august-workshop/), [GitHub repository](https://github.com/dcppc/2018-august-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/16oNTuVSPMa4sjCRUG1q60DpoFi43GRn2) 
 
 ### July Workshop: July 25-26, 2018 in Chapel Hill, NC 
-* Resources: [workshop website](http://nih-data-commons.us/2018-july-workshop/), [GitHub repository](https://github.com/dcppc/2018-july-workshop) 
+* Resources: [workshop website](http://nih-data-commons.us/2018-july-workshop/), [GitHub repository](https://github.com/dcppc/2018-july-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/1Ues8Pa_xV6Vvbg0-4uBuK_5EBefDkEEK) 
+* Videos: [Day 1 and 2 lightning talk playlist](https://archive.org/details/2018-july-workshop-lightningtalks) and [breakout group playlist](https://archive.org/details/2018-august-workshopbreakoutgroups). 
 
 ### June Workshop: June 29-30, 2018 in Portland, OR
 * Resources:  [website](http://nih-data-commons.us/2018-june-workshop/), [GitHub repository](https://github.com/dcppc/2018-june-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/19oA9Us4-2ev3UeKDYN1d2D9UjNNS7llk)
 * Lightning talk recordings: [Day 1](https://archive.org/details/13TeamXenonCharlieWhicherJune2018), [Day 2](https://archive.org/details/June2018DCPPCworkshoptalksday1)
+* Post-workshop assessment: [Full report](https://pilot.nihdatacommons.us/internal/Assessment/2018-June-Report-Full/), [Summary report](https://pilot.nihdatacommons.us/internal/Assessment/2018-June-Report-Summary/)
 
 ### May Workshop: May 30-31, 2018 in Boston, MA
 * Resources: [website](http://nih-data-commons.us/2018-may-workshop/), [GitHub repository](https://github.com/dcppc/2018-may-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/1t9mLxGfNEOny220snt5I2xDVxuIM-AUY)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The issues and projects and documents within this repository are used to organiz
 
 ### July Workshop: July 25-26, 2018 in Chapel Hill, NC 
 * Resources: [workshop website](http://nih-data-commons.us/2018-july-workshop/), [GitHub repository](https://github.com/dcppc/2018-july-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/1Ues8Pa_xV6Vvbg0-4uBuK_5EBefDkEEK) 
-* Videos: [Day 1 and 2 lightning talk playlist](https://archive.org/details/2018-july-workshop-lightningtalks) and [breakout group playlist](https://archive.org/details/2018-august-workshopbreakoutgroups). 
+* Videos: [Day 1 and 2 lightning talk playlist](https://archive.org/details/2018-july-workshop-lightningtalks), [breakout group playlist](https://archive.org/details/2018-august-workshopbreakoutgroups), and [interviews with Dr Rebecca Calisi](https://vimeo.com/album/5235887) 
 
 ### June Workshop: June 29-30, 2018 in Portland, OR
 * Resources:  [website](http://nih-data-commons.us/2018-june-workshop/), [GitHub repository](https://github.com/dcppc/2018-june-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/19oA9Us4-2ev3UeKDYN1d2D9UjNNS7llk)
@@ -28,7 +28,7 @@ The issues and projects and documents within this repository are used to organiz
 
 ### May Workshop: May 30-31, 2018 in Boston, MA
 * Resources: [website](http://nih-data-commons.us/2018-may-workshop/), [GitHub repository](https://github.com/dcppc/2018-may-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/1t9mLxGfNEOny220snt5I2xDVxuIM-AUY)
-* Lightning talk recordings: [Day 1](https://archive.org/details/commonspilot-may2018workshop-day01) and [Day 2](https://archive.org/details/commonspilot-may2018workshop-day02)
+* Videos: [Day 1 talks](https://archive.org/details/commonspilot-may2018workshop-day01), [Day 2 talks](https://archive.org/details/commonspilot-may2018workshop-day02), and [interviews with Dr Rebecca Calisi](https://vimeo.com/album/5235887) 
 * Post-workshop assessment: [Full report](https://pilot.nihdatacommons.us/internal/Assessment/2018-May-Report-Full/), [Summary report](https://pilot.nihdatacommons.us/internal/Assessment/2018-May-Report-Summary/)
 
 ### April F2F Meeting: April 27, 2018 in Bethesda, MD

--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# dcppc-workshops
+# DCPPC Workshops and Face2Face Meetings
 
-A _public_ repository for organizing the monthly DCPPC workshops.
+This repository serves as a collection of resources related to the Data Commons Pilot Phase Consortium (DCPPC) 
+Face2Face meetings and workshops (which each have their own repository and website). 
 
-Click on the [Projects](https://github.com/dcppc/dcppc-workshops/projects) 
-button above to view the dashboards for each montly meeting. 
-Or, click the [Issues](https://github.com/dcppc/dcppc-workshops/issues) 
-to view all the issues related to the workshops in list form. 
+This README provides an overview of all outputs from the workshops.
+The issues and projects and documents within this repository are used to organize and plan upcoming workshops.
 
-All members of the Commons are expected to agree with the our 
-[code of conduct](https://github.com/dcppc/dcppc-workshops/blob/master/CODE_OF_CONDUCT.md). 
-We will enforce this code as needed. We expect cooperation 
-from all members to help ensuring a safe environment for everybody. 
+## 2018 
 
-## Workshops in the works 
+### October Workshop: October 15-16, 2018 in Bethesda, MD
+* Resources: _See [this email from Titus Brown](https://dcppc.groups.io/g/leads/message/184)_ 
+ 
+### September Workshop: September 20-21, 2018 in Boston, MA 
+* Resources: [workshop website](http://nih-data-commons.us/2018-september-workshop/), [GitHub repository](https://github.com/dcppc/2018-september-workshop)
 
-| Where | When | Planned in concert with | Website | 
-| --- | --- | --- | --- |
-| Boston, MA |May 30 - 31 | Harvard | [website](http://nih-data-commons.us/2018-may-workshop/)| 
-| Portland, OR |June 29 - 30 | BOSC | [website](http://nih-data-commons.us/2018-june-workshop/) |
-| Chapel Hill, NC | July 25-26 | RENCI | [website](http://nih-data-commons.us/2018-july-workshop/) |
-| Chicago, IL | Aug. 27-28 | help from Rick Wagner | [website](http://nih-data-commons.us/2018-august-workshop/) |
-| Boston, MA | Sept 20-21 | help from Merce Crosas | [website](http://nih-data-commons.us/2018-september-workshop/) |
-| NIH | October 16  | organized by NIH |  |
+### August Workshop: August 27-28, 2018 in Chicago, IL
+* Resources: [workshop website](http://nih-data-commons.us/2018-august-workshop/), [GitHub repository](https://github.com/dcppc/2018-august-workshop)  
+
+### July Workshop: July 25-26, 2018 in Chapel Hill, NC 
+* Resources: [workshop website](http://nih-data-commons.us/2018-july-workshop/), [GitHub repository](https://github.com/dcppc/2018-july-workshop) 
+
+### June Workshop: June 29-30, 2018 in Portland, OR
+* Resources:  [website](http://nih-data-commons.us/2018-june-workshop/), [GitHub repository](https://github.com/dcppc/2018-june-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/19oA9Us4-2ev3UeKDYN1d2D9UjNNS7llk)
+* Lightning talk recordings: [Day 1](https://archive.org/details/13TeamXenonCharlieWhicherJune2018), [Day 2](https://archive.org/details/June2018DCPPCworkshoptalksday1)
+
+### May Workshop: May 30-31, 2018 in Boston, MA
+* Resources: [website](http://nih-data-commons.us/2018-may-workshop/), [GitHub repository](https://github.com/dcppc/2018-may-workshop), [Google Drive](https://drive.google.com/drive/u/0/folders/1t9mLxGfNEOny220snt5I2xDVxuIM-AUY)
+* Lightning talk recordings: [Day 1](https://archive.org/details/commonspilot-may2018workshop-day01) and [Day 2](https://archive.org/details/commonspilot-may2018workshop-day02)
+* Post-workshop assessment: [Full report](https://pilot.nihdatacommons.us/internal/Assessment/2018-May-Report-Full/), [Summary report](https://pilot.nihdatacommons.us/internal/Assessment/2018-May-Report-Summary/)
+
+### April F2F Meeting: April 27, 2018 in Bethesda, MD
+* Resources: [Google Drive](https://drive.google.com/drive/u/0/folders/1c5mV8_YeURKnlpGVQeZwuz5a1E3kk-n8)
+
+## 2017
+
+### 2017 Commons Pilot Kickoff Meeting: December 7-8, 2017 in Bethesda, MD
+* Resources: [Google Drive](https://drive.google.com/drive/u/0/folders/1GyIlC-LrW31-OmEU_Rz3PTQTDG54R1Ne)
+* Blog posts: [Titus Brown's _The #CommonsPilot kicks off_](http://ivory.idyll.org/blog/2017-commonspilot-kickoff.html)
+


### PR DESCRIPTION
updating the readme rather than internal, as per https://github.com/dcppc/internal/pull/67